### PR TITLE
Use Injector to set new controllers, instead of overwrites routes

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -11,7 +11,8 @@ SiteTree:
 Name: modelascontrollerroutes
 After: cms/routes#modelascontrollerroutes
 ---
-Director:
-    rules:
-        '': 'AllInOneRootController'
-        '$URLSegment//$Action/$ID/$OtherID': 'AllInOneModelAsController'
+Injector:
+    ModelAsController:
+        class: AllInOneModelAsController
+    RootURLController:
+        class: AllInOneRootController


### PR DESCRIPTION
Overwriting routes to point at this modules controllers wrecked all functionality when Fluent or Translatable was installed.

This way we will use Injector to simple replace the core controllers with the module's controllers